### PR TITLE
feat: persistencia con Room y animaciones de publicación

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    kotlin("kapt")
 }
 
 android {
@@ -56,6 +57,9 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.6")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.6")
     implementation("androidx.datastore:datastore-preferences:1.1.1")
+    implementation("androidx.room:room-runtime:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+    kapt("androidx.room:room-compiler:2.6.1")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/joel/duoclinkayudantia/data/AppDatabase.kt
+++ b/app/src/main/java/com/joel/duoclinkayudantia/data/AppDatabase.kt
@@ -1,0 +1,24 @@
+package com.joel.duoclinkayudantia.data
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import com.joel.duoclinkayudantia.model.Ayudantia
+
+@Database(entities = [Ayudantia::class], version = 1, exportSchema = false)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun ayudantiaDao(): AyudantiaDao
+
+    companion object {
+        @Volatile private var INSTANCE: AppDatabase? = null
+        fun get(context: Context): AppDatabase =
+            INSTANCE ?: synchronized(this) {
+                INSTANCE ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    AppDatabase::class.java,
+                    "ayudantias.db"
+                ).build().also { INSTANCE = it }
+            }
+    }
+}

--- a/app/src/main/java/com/joel/duoclinkayudantia/data/AyudantiaDao.kt
+++ b/app/src/main/java/com/joel/duoclinkayudantia/data/AyudantiaDao.kt
@@ -1,0 +1,23 @@
+package com.joel.duoclinkayudantia.data
+
+import androidx.room.*
+import com.joel.duoclinkayudantia.model.Ayudantia
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface AyudantiaDao {
+    @Query("SELECT * FROM ayudantias ORDER BY id DESC")
+    fun getAll(): Flow<List<Ayudantia>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(ayudantia: Ayudantia): Long
+
+    @Update
+    suspend fun update(ayudantia: Ayudantia)
+
+    @Delete
+    suspend fun delete(ayudantia: Ayudantia)
+
+    @Query("SELECT * FROM ayudantias WHERE id = :id LIMIT 1")
+    suspend fun getById(id: Int): Ayudantia?
+}

--- a/app/src/main/java/com/joel/duoclinkayudantia/data/repository/AyudantiaRepository.kt
+++ b/app/src/main/java/com/joel/duoclinkayudantia/data/repository/AyudantiaRepository.kt
@@ -1,0 +1,17 @@
+package com.joel.duoclinkayudantia.data.repository
+
+import com.joel.duoclinkayudantia.data.AyudantiaDao
+import com.joel.duoclinkayudantia.model.Ayudantia
+import kotlinx.coroutines.flow.Flow
+
+class AyudantiaRepository(private val dao: AyudantiaDao) {
+    val ayudantias: Flow<List<Ayudantia>> = dao.getAll()
+
+    suspend fun upsert(ayudantia: Ayudantia) {
+        if (ayudantia.id == 0) dao.insert(ayudantia) else dao.update(ayudantia)
+    }
+
+    suspend fun delete(ayudantia: Ayudantia) = dao.delete(ayudantia)
+
+    suspend fun get(id: Int) = dao.getById(id)
+}

--- a/app/src/main/java/com/joel/duoclinkayudantia/model/Ayudantia.kt
+++ b/app/src/main/java/com/joel/duoclinkayudantia/model/Ayudantia.kt
@@ -1,0 +1,16 @@
+package com.joel.duoclinkayudantia.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "ayudantias")
+data class Ayudantia(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val publicadoPor: String,
+    val tema: String,
+    val lugar: String,
+    val hora: String,
+    val dia: String,
+    val cupos: Int,
+    val duracion: Int
+)

--- a/app/src/main/java/com/joel/duoclinkayudantia/ui/screens/AyudantiasScreen.kt
+++ b/app/src/main/java/com/joel/duoclinkayudantia/ui/screens/AyudantiasScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.joel.duoclinkayudantia.navigation.AppRoute
-import com.joel.duoclinkayudantia.viewmodel.Ayudantia
+import com.joel.duoclinkayudantia.model.Ayudantia
 import com.joel.duoclinkayudantia.viewmodel.AyudantiaViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -36,6 +36,7 @@ fun AyudantiasScreen(
                 Button(
                     onClick = {
                         vm.eliminarAyudantia(ayudantiaParaEliminar!!)
+                        ayudantiaParaEliminar = null
                         showDialog = false
                     },
                     colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
@@ -68,11 +69,10 @@ fun AyudantiasScreen(
                 Text(
                     "Ayudantías Disponibles",
                     style = MaterialTheme.typography.headlineMedium,
-                    modifier = Modifier.weight(1f) // Ocupa el espacio disponible
+                    modifier = Modifier.weight(1f)
                 )
                 Button(
                     onClick = { navController.navigate(AppRoute.CrearAyudantia.path) },
-                    // El botón se alinea correctamente con el texto
                 ) {
                     Text("Publicar Ayudantía")
                 }

--- a/app/src/main/java/com/joel/duoclinkayudantia/ui/screens/FormularioAyudantiaScreen.kt
+++ b/app/src/main/java/com/joel/duoclinkayudantia/ui/screens/FormularioAyudantiaScreen.kt
@@ -5,9 +5,12 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.background
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -19,6 +22,7 @@ import androidx.navigation.NavController
 import com.joel.duoclinkayudantia.viewmodel.AyudantiaViewModel
 import java.text.SimpleDateFormat
 import java.util.*
+import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -42,8 +46,11 @@ fun FormularioAyudantiaScreen(
         }
     }
 
+    // Espera 1s mostrando el check y luego navega atrás
     LaunchedEffect(formState.success) {
         if (formState.success) {
+            delay(1000)
+            vm.dismissSuccess()
             navController.popBackStack()
         }
     }
@@ -59,15 +66,9 @@ fun FormularioAyudantiaScreen(
                         val date = formatter.format(Date(millis))
                         vm.onFormValueChange(dia = date)
                     }
-                }) {
-                    Text("Aceptar")
-                }
+                }) { Text("Aceptar") }
             },
-            dismissButton = {
-                TextButton(onClick = { showDatePicker = false }) {
-                    Text("Cancelar")
-                }
-            }
+            dismissButton = { TextButton(onClick = { showDatePicker = false }) { Text("Cancelar") } }
         ) {
             DatePicker(state = datePickerState)
         }
@@ -85,134 +86,194 @@ fun FormularioAyudantiaScreen(
             )
         }
     ) { padding ->
-        Column(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .padding(16.dp)
-                .verticalScroll(rememberScrollState()),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            OutlinedTextField(
-                value = formState.publicadoPor,
-                onValueChange = { },
-                label = { Text("Publicado Por") },
-                modifier = Modifier.fillMaxWidth(),
-                readOnly = true,
-                enabled = false
-            )
-
-            OutlinedTextField(
-                value = formState.tema,
-                onValueChange = { vm.onFormValueChange(tema = it) },
-                label = { Text("Tema") },
-                modifier = Modifier.fillMaxWidth(),
-                isError = formState.temaError != null,
-                supportingText = { formState.temaError?.let { Text(it) } }
-            )
-
-            OutlinedTextField(
-                value = formState.lugar,
-                onValueChange = { vm.onFormValueChange(lugar = it) },
-                label = { Text("Lugar") },
-                modifier = Modifier.fillMaxWidth(),
-                isError = formState.lugarError != null,
-                supportingText = { formState.lugarError?.let { Text(it) } }
-            )
-
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+                    .verticalScroll(rememberScrollState()),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
                 OutlinedTextField(
-                    value = formState.dia,
+                    value = formState.publicadoPor,
                     onValueChange = { },
-                    label = { Text("Día") },
-                    modifier = Modifier
-                        .weight(1f)
-                        .clickable { showDatePicker = true },
-                    isError = formState.diaError != null,
-                    supportingText = { formState.diaError?.let { Text(it) } },
+                    label = { Text("Publicado Por") },
+                    modifier = Modifier.fillMaxWidth(),
                     readOnly = true,
-                    enabled = false,
-                    trailingIcon = {
-                        Icon(
-                            Icons.Default.DateRange,
-                            contentDescription = "Seleccionar fecha",
-                            modifier = Modifier.clickable { showDatePicker = true }
-                        )
-                    },
-                    colors = OutlinedTextFieldDefaults.colors(
-                        disabledTextColor = MaterialTheme.colorScheme.onSurface,
-                        disabledBorderColor = MaterialTheme.colorScheme.outline,
-                        disabledPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                        disabledLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                        disabledLeadingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                        disabledTrailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                    enabled = false
                 )
-                
-                Row(
-                    modifier = Modifier.weight(1f),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
+
+                OutlinedTextField(
+                    value = formState.tema,
+                    onValueChange = { vm.onFormValueChange(tema = it) },
+                    label = { Text("Tema") },
+                    modifier = Modifier.fillMaxWidth(),
+                    isError = formState.temaError != null,
+                    supportingText = { formState.temaError?.let { Text(it) } }
+                )
+
+                OutlinedTextField(
+                    value = formState.lugar,
+                    onValueChange = { vm.onFormValueChange(lugar = it) },
+                    label = { Text("Lugar") },
+                    modifier = Modifier.fillMaxWidth(),
+                    isError = formState.lugarError != null,
+                    supportingText = { formState.lugarError?.let { Text(it) } }
+                )
+
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     OutlinedTextField(
-                        value = formState.horaInput,
-                        onValueChange = { if (it.length <= 2) vm.onFormValueChange(horaInput = it) },
-                        label = { Text("HH") },
-                        modifier = Modifier.weight(1f),
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                        isError = formState.horaError != null
+                        value = formState.dia,
+                        onValueChange = { },
+                        label = { Text("Día") },
+                        modifier = Modifier
+                            .weight(1f)
+                            .clickable { showDatePicker = true },
+                        isError = formState.diaError != null,
+                        supportingText = { formState.diaError?.let { Text(it) } },
+                        readOnly = true,
+                        enabled = false,
+                        trailingIcon = {
+                            Icon(
+                                Icons.Default.DateRange,
+                                contentDescription = "Seleccionar fecha",
+                                modifier = Modifier.clickable { showDatePicker = true }
+                            )
+                        },
+                        colors = OutlinedTextFieldDefaults.colors(
+                            disabledTextColor = MaterialTheme.colorScheme.onSurface,
+                            disabledBorderColor = MaterialTheme.colorScheme.outline,
+                            disabledPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            disabledLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            disabledLeadingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            disabledTrailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
                     )
-                    Text(":", style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 8.dp))
-                    OutlinedTextField(
-                        value = formState.minutoInput,
-                        onValueChange = { if (it.length <= 2) vm.onFormValueChange(minutoInput = it) },
-                        label = { Text("MM") },
+
+                    Row(
                         modifier = Modifier.weight(1f),
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                        isError = formState.horaError != null
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        OutlinedTextField(
+                            value = formState.horaInput,
+                            onValueChange = { if (it.length <= 2) vm.onFormValueChange(horaInput = it) },
+                            label = { Text("HH") },
+                            modifier = Modifier.weight(1f),
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                            isError = formState.horaError != null
+                        )
+                        Text(":", style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 8.dp))
+                        OutlinedTextField(
+                            value = formState.minutoInput,
+                            onValueChange = { if (it.length <= 2) vm.onFormValueChange(minutoInput = it) },
+                            label = { Text("MM") },
+                            modifier = Modifier.weight(1f),
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                            isError = formState.horaError != null
+                        )
+                    }
+                }
+
+                if (formState.horaError != null) {
+                    Text(
+                        text = formState.horaError!!,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 16.dp)
                     )
                 }
-            }
-            // Muestra el mensaje de error para la hora debajo de los campos
-            if (formState.horaError != null) {
-                Text(
-                    text = formState.horaError!!,
-                    color = MaterialTheme.colorScheme.error,
-                    style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier.fillMaxWidth().padding(start = 16.dp)
-                )
+
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = formState.cupos,
+                        onValueChange = { vm.onFormValueChange(cupos = it) },
+                        label = { Text("Cupos") },
+                        modifier = Modifier.weight(1f),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        isError = formState.cuposError != null,
+                        supportingText = { formState.cuposError?.let { Text(it) } }
+                    )
+                    OutlinedTextField(
+                        value = formState.duracion,
+                        onValueChange = { vm.onFormValueChange(duracion = it) },
+                        label = { Text("Duración") },
+                        modifier = Modifier.weight(1f),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        isError = formState.duracionError != null,
+                        supportingText = { formState.duracionError?.let { Text(it) } },
+                        suffix = { Text("min") }
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Button(
+                    onClick = { vm.guardarAyudantia() },
+                    enabled = !formState.isLoading && !formState.success,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Guardar Ayudantía")
+                }
             }
 
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedTextField(
-                    value = formState.cupos,
-                    onValueChange = { vm.onFormValueChange(cupos = it) },
-                    label = { Text("Cupos") },
-                    modifier = Modifier.weight(1f),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    isError = formState.cuposError != null,
-                    supportingText = { formState.cuposError?.let { Text(it) } }
-                )
-                OutlinedTextField(
-                    value = formState.duracion,
-                    onValueChange = { vm.onFormValueChange(duracion = it) },
-                    label = { Text("Duración") },
-                    modifier = Modifier.weight(1f),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    isError = formState.duracionError != null,
-                    supportingText = { formState.duracionError?.let { Text(it) } },
-                    suffix = { Text("min") }
-                )
+            // Overlay de carga
+            if (formState.isLoading) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.35f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Surface(
+                        shape = RoundedCornerShape(16.dp),
+                        tonalElevation = 6.dp
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(24.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            CircularProgressIndicator()
+                            Text("Publicando ayudantía...")
+                        }
+                    }
+                }
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
-
-            Button(
-                onClick = { vm.guardarAyudantia() },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text("Guardar Ayudantía")
+            // Overlay de éxito por 1 segundo
+            if (!formState.isLoading && formState.success) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.35f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Surface(
+                        shape = RoundedCornerShape(16.dp),
+                        tonalElevation = 6.dp
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(24.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.CheckCircle,
+                                contentDescription = "Éxito",
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                            Text("¡Ayudantía publicada!")
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Descripción
Implementada persistencia local con Room (Entidad Ayudantia, AyudantiaDao, AppDatabase, AyudantiaRepository) y adaptación del AyudantiaViewModel para CRUD real. Añadidas animaciones/overlays de carga y éxito al publicar (CircularProgressIndicator + overlay de check). Se bloquea el botón durante la operación para evitar duplicados. Relacionado con: #21 (Persistencia Room) y #22 (Animaciones de carga publicación).

## Impacto
- Áreas afectadas:
  - Capa de datos: nuevos archivos (model/Ayudantia, data/AyudantiaDao, data/AppDatabase, data/repository/AyudantiaRepository).
  - ViewModel: manejo de estados isLoading, success, guard anti reentradas.
  - UI: FormularioAyudantiaScreen (overlays de carga y éxito, deshabilitar botón), AyudantiasScreen (import y uso de modelo persistente).
  - Gradle: dependencias Room y kapt añadidas.

## Checklist (DoD)
- [x] Compila en local (`./gradlew build`)
- [ ] CI verde (verificar pipeline)
- [x] UI sigue la paleta (Duoc Blue/Yellow/Gray/White) (revisar colores; overlays usan Material defaults)
- [x] Validaciones y mensajes de error básicos (tema, lugar, hora, día, cupos, duración)
- [ ] Capturas o video si cambia UI (pendiente adjuntar)
- [x] Commits claros (convencional) y PR vinculado a Issue (#21, #22) 
- [x] Notas de prueba manual incluidas (ver abajo)

## Notas de prueba manual
1. Crear ayudantía: completar campos válidos, presionar Guardar -> overlay de carga (2s) -> overlay éxito (1s) -> retorno a lista.
2. Botón Guardar deshabilitado en carga y éxito; no se duplica entrada.
3. Validaciones: dejar campos vacíos para ver mensajes específicos.
4. Editar ayudantía existente: datos se precargan, guardar actualiza en lista.
5. Eliminar desde AyudantiasScreen: diálogo confirmación y desaparición inmediata.
6. Inspección DB (Database Inspector) confirma tabla ayudantias y filas insertadas.

